### PR TITLE
Fix: Error generate report forum #18

### DIFF
--- a/classes/report.php
+++ b/classes/report.php
@@ -212,7 +212,7 @@ class report extends grade_report {
              LEFT JOIN {grading_areas} area ON def.areaid = area.id
              LEFT JOIN {gradingform_rubric_fillings} fill ON inst.id = fill.instanceid
                  WHERE act.userid $insql AND inst.status = ? AND act.{$field} = ? AND area.contextid = ?
-              ORDER BY act.userid ASC, act.attemptnumber DESC";
+              ORDER BY act.userid ASC";
 
         $userdata = $DB->get_recordset_sql($sql, $inparams);
         $udataarray = [];


### PR DESCRIPTION
After analyzing the code, although the table with the alias act is variable depending on the module, none of the analyzed Moodle modules has the attemptnumber field, therefore, I chose to remove it from the query.
Closes #18 